### PR TITLE
Let Hadolint trust docker.io registry

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,8 @@ jobs:
      - uses: actions/checkout@v3
      - name: Run hadolint
        uses: hadolint/hadolint-action@v1.7.0
+       with:
+         trusted-registries: docker.io
 
   test:
     name: Build image and test basic functionality


### PR DESCRIPTION
Fixes [DL3026](https://github.com/hadolint/hadolint/wiki/DL3026).
